### PR TITLE
Display sender from received funds in Recent Activity list

### DIFF
--- a/packages/modern-ui/src/components/HistoryList/HistoryListRow.tsx
+++ b/packages/modern-ui/src/components/HistoryList/HistoryListRow.tsx
@@ -46,7 +46,7 @@ const HistoryListRow: React.FC<HistoryListEventProps> = ({ event, account, navig
         <Row onClick={() => navigateTo(`/receipt/${asset.id}/${event.tx}`)}>
           <div>
             <span>
-              <Address address={event.to} />
+              <Address address={didReceive ? event.from : event.to} />
             </span>
             <div>
               {didReceive ? t('Received funds') : t('Sent funds')}


### PR DESCRIPTION
When receiving funds, the address of the account in the wallet is displayed in the list row. For this case, I think that it makes sense to show the address from the account that sent the funds to our account.

Before:
![before](https://user-images.githubusercontent.com/4614574/79782044-ce2f1c80-8314-11ea-91b6-c77eb297c6b9.png)

After:
![after](https://user-images.githubusercontent.com/4614574/79782051-d0917680-8314-11ea-9525-07b81546879b.png)
