### PR TITLE
Add functionality to display information from exchange estimate

### DIFF
--- a/packages/exchange/src/index.ts
+++ b/packages/exchange/src/index.ts
@@ -2,7 +2,7 @@ import Exchange from './Exchange';
 
 export default Exchange;
 
-export { default as Pair, ValueTypes, ExchangeParams } from './pairs/Pair';
+export { default as Pair, ValueTypes, ExchangeParams, EstimateReturn } from './pairs/Pair';
 export { default as Uniswap } from './pairs/Uniswap';
 export { default as XDaiBridge } from './pairs/XDaiBridge';
 export { default as Bridge } from './pairs/Bridge';

--- a/packages/exchange/src/pairs/Bridge.ts
+++ b/packages/exchange/src/pairs/Bridge.ts
@@ -36,14 +36,14 @@ export default class Bridge extends Pair {
     async estimateAtoB(value: ValueTypes) {
         return {
             estimate: this._getValue(value),
-            estimateMessage: null
+            estimateInfo: null
         };
     }
 
     async estimateBtoA(value: ValueTypes) {
         return {
             estimate: this._getValue(value),
-            estimateMessage: null
+            estimateInfo: null
         };
     }
 

--- a/packages/exchange/src/pairs/Bridge.ts
+++ b/packages/exchange/src/pairs/Bridge.ts
@@ -34,11 +34,17 @@ export default class Bridge extends Pair {
     }
 
     async estimateAtoB(value: ValueTypes) {
-        return this._getValue(value);
+        return {
+            estimate: this._getValue(value),
+            estimateMessage: null
+        };
     }
 
     async estimateBtoA(value: ValueTypes) {
-        return this._getValue(value);
+        return {
+            estimate: this._getValue(value),
+            estimateMessage: null
+        };
     }
 
     getLoadingMessage(): string {

--- a/packages/exchange/src/pairs/Pair.ts
+++ b/packages/exchange/src/pairs/Pair.ts
@@ -10,6 +10,11 @@ export interface ExchangeParams extends ValueTypes {
   account: string;
 }
 
+export interface EstimateReturn {
+  estimate: string;
+  estimateMessage: null | string;
+}
+
 interface PairConstructor {
   assetA: string;
   assetB: string;
@@ -29,8 +34,8 @@ export default abstract class Pair {
   abstract exchangeAtoB({ account, value, ether }: ExchangeParams): Promise<void>;
   abstract exchangeBtoA({ account, value, ether }: ExchangeParams): Promise<void>;
 
-  abstract estimateAtoB(value: ValueTypes): Promise<string>;
-  abstract estimateBtoA(value: ValueTypes): Promise<string>;
+  abstract estimateAtoB(value: ValueTypes): Promise<EstimateReturn>;
+  abstract estimateBtoA(value: ValueTypes): Promise<EstimateReturn>;
 
   setExchange(newExchange: Exchange) {
     this._exchange = newExchange;

--- a/packages/exchange/src/pairs/Pair.ts
+++ b/packages/exchange/src/pairs/Pair.ts
@@ -12,7 +12,7 @@ export interface ExchangeParams extends ValueTypes {
 
 export interface EstimateReturn {
   estimate: string;
-  estimateMessage: null | string;
+  estimateInfo: null | string;
 }
 
 interface PairConstructor {

--- a/packages/exchange/src/pairs/Uniswap.ts
+++ b/packages/exchange/src/pairs/Uniswap.ts
@@ -75,12 +75,18 @@ export default class Uniswap extends Pair {
   async estimateAtoB(value: ValueTypes) {
     const contract = await this.getContract();
     const output = await contract.methods.getTokenToEthInputPrice(this._getValue(value)).call();
-    return output;
+    return {
+      estimate: output,
+      estimateMessage: null
+    };
   }
 
   async estimateBtoA(value: ValueTypes) {
     const contract = await this.getContract();
     const output = await contract.methods.getEthToTokenInputPrice(this._getValue(value)).call();
-    return output;
+    return {
+      estimate: output,
+      estimateMessage: null
+    };
   }
 }

--- a/packages/exchange/src/pairs/Uniswap.ts
+++ b/packages/exchange/src/pairs/Uniswap.ts
@@ -77,7 +77,7 @@ export default class Uniswap extends Pair {
     const output = await contract.methods.getTokenToEthInputPrice(this._getValue(value)).call();
     return {
       estimate: output,
-      estimateMessage: null
+      estimateInfo: null
     };
   }
 
@@ -86,7 +86,7 @@ export default class Uniswap extends Pair {
     const output = await contract.methods.getEthToTokenInputPrice(this._getValue(value)).call();
     return {
       estimate: output,
-      estimateMessage: null
+      estimateInfo: null
     };
   }
 }

--- a/packages/exchange/src/ui/ExchangePage.tsx
+++ b/packages/exchange/src/ui/ExchangePage.tsx
@@ -23,11 +23,17 @@ const ErrorBar = styled.div`
   margin-bottom: 4px;
 `;
 
+const EstimateMessage = styled.div`
+  min-height: 18px;
+  margin: 8px;
+`;
+
 interface ExchangePageState {
   assetA: Asset;
   assetB: Asset;
   amount: string;
   estimate: null | string;
+  estimateMessage: null | string;
   isExchanging: boolean;
   error: string | null;
 }
@@ -43,6 +49,7 @@ export default class ExchangePage extends Component<PluginPageContext<{}, Exchan
       assetB: this.props.plugin.getAsset(firstPair.assetB),
       amount: '',
       estimate: null,
+      estimateMessage: null,
       isExchanging: false,
       error: null,
     };
@@ -95,7 +102,10 @@ export default class ExchangePage extends Component<PluginPageContext<{}, Exchan
       return estimate;
     } catch (e) {
       console.error(e);
-      return null;
+      return {
+        estimate: null,
+        estimateMessage: null
+      };
     }
   }
 
@@ -115,7 +125,7 @@ export default class ExchangePage extends Component<PluginPageContext<{}, Exchan
   }
 
   async update({ assetA, assetB, amount }: { assetA?: Asset; assetB?: Asset; amount?: string }) {
-    const update: Partial<ExchangePageState> = { estimate: null };
+    const update: Partial<ExchangePageState> = { estimate: null, estimateMessage: null };
     if (assetA) {
       update.assetA = assetA;
 
@@ -137,19 +147,19 @@ export default class ExchangePage extends Component<PluginPageContext<{}, Exchan
       return;
     }
 
-    const estimate = await this.getEstimate(start.assetA, start.assetB, start.amount);
+    const { estimate, estimateMessage } = await this.getEstimate(start.assetA, start.assetB, start.amount);
 
     // Check if anything has changed while the estimate was fetching.
     if (this.state.assetA === start.assetA
       && this.state.assetB === start.assetB
       && this.state.amount === start.amount) {
-        this.setState({ estimate });
+        this.setState({ estimate, estimateMessage });
     }
   }
 
   render() {
     const { burnerComponents } = this.props;
-    const { assetA, assetB, amount, estimate, isExchanging, error } = this.state;
+    const { assetA, assetB, amount, estimate, isExchanging, error, estimateMessage } = this.state;
     const { Page, AssetSelector, Button } = burnerComponents;
 
     const assetBOptions = this.getPairOptions(assetA);
@@ -166,6 +176,7 @@ export default class ExchangePage extends Component<PluginPageContext<{}, Exchan
             outputUnit={assetB.name}
             disabled={isExchanging}
           />
+          <EstimateMessage>{estimateMessage}</EstimateMessage>
         </InputContainer>
 
         <div>

--- a/packages/exchange/src/ui/ExchangePage.tsx
+++ b/packages/exchange/src/ui/ExchangePage.tsx
@@ -23,7 +23,7 @@ const ErrorBar = styled.div`
   margin-bottom: 4px;
 `;
 
-const EstimateMessage = styled.div`
+const EstimateInfo = styled.div`
   min-height: 18px;
   margin: 8px;
 `;
@@ -33,7 +33,7 @@ interface ExchangePageState {
   assetB: Asset;
   amount: string;
   estimate: null | string;
-  estimateMessage: null | string;
+  estimateInfo: null | string;
   isExchanging: boolean;
   error: string | null;
 }
@@ -49,7 +49,7 @@ export default class ExchangePage extends Component<PluginPageContext<{}, Exchan
       assetB: this.props.plugin.getAsset(firstPair.assetB),
       amount: '',
       estimate: null,
-      estimateMessage: null,
+      estimateInfo: null,
       isExchanging: false,
       error: null,
     };
@@ -104,7 +104,7 @@ export default class ExchangePage extends Component<PluginPageContext<{}, Exchan
       console.error(e);
       return {
         estimate: null,
-        estimateMessage: null
+        estimateInfo: null
       };
     }
   }
@@ -125,7 +125,7 @@ export default class ExchangePage extends Component<PluginPageContext<{}, Exchan
   }
 
   async update({ assetA, assetB, amount }: { assetA?: Asset; assetB?: Asset; amount?: string }) {
-    const update: Partial<ExchangePageState> = { estimate: null, estimateMessage: null };
+    const update: Partial<ExchangePageState> = { estimate: null, estimateInfo: null };
     if (assetA) {
       update.assetA = assetA;
 
@@ -147,19 +147,19 @@ export default class ExchangePage extends Component<PluginPageContext<{}, Exchan
       return;
     }
 
-    const { estimate, estimateMessage } = await this.getEstimate(start.assetA, start.assetB, start.amount);
+    const { estimate, estimateInfo } = await this.getEstimate(start.assetA, start.assetB, start.amount);
 
     // Check if anything has changed while the estimate was fetching.
     if (this.state.assetA === start.assetA
       && this.state.assetB === start.assetB
       && this.state.amount === start.amount) {
-        this.setState({ estimate, estimateMessage });
+        this.setState({ estimate, estimateInfo });
     }
   }
 
   render() {
     const { burnerComponents } = this.props;
-    const { assetA, assetB, amount, estimate, isExchanging, error, estimateMessage } = this.state;
+    const { assetA, assetB, amount, estimate, isExchanging, error, estimateInfo } = this.state;
     const { Page, AssetSelector, Button } = burnerComponents;
 
     const assetBOptions = this.getPairOptions(assetA);
@@ -176,7 +176,7 @@ export default class ExchangePage extends Component<PluginPageContext<{}, Exchan
             outputUnit={assetB.name}
             disabled={isExchanging}
           />
-          <EstimateMessage>{estimateMessage}</EstimateMessage>
+          <EstimateInfo>{estimateInfo}</EstimateInfo>
         </InputContainer>
 
         <div>


### PR DESCRIPTION
This PR adds the functionality to allow exchanges Pairs to display custom information related to the estimate of the exchange operation.

This is useful for example for bridge pairs that have fees in the operations so at the moment of informing the estimated value the user is going to receive on the other asset, a message can be displayed informing of the fee charged to the user.

This also can be useful for the Uniswap pair that could use this field to display the exchange rate for example between ETH <> DAI when estimating the receiving value.

Right now, XDAIBridge (does not have fees) and Uniswap pairs do not provide any information on the estimation so there shouldn't be any changes from the user perspective only a little bigger space between the inputs and the assets dropdown.

I tested adding a custom estimate information to display in XDAIBridge and this is how it looks:

![estimateMessage](https://user-images.githubusercontent.com/4614574/80023347-c48feb00-84b3-11ea-86bb-3df2147b1326.gif)


