### PR TITLE
Fix exchange Bridge estimate methods types

### DIFF
--- a/packages/exchange/src/pairs/Bridge.ts
+++ b/packages/exchange/src/pairs/Bridge.ts
@@ -1,4 +1,4 @@
-import Pair, { ExchangeParams, ValueTypes } from './Pair';
+import Pair, { EstimateReturn, ExchangeParams, ValueTypes } from './Pair';
 
 interface BridgePairConstructor {
     assetA: string;
@@ -33,14 +33,14 @@ export default class Bridge extends Pair {
         return result;
     }
 
-    async estimateAtoB(value: ValueTypes) {
+    async estimateAtoB(value: ValueTypes): Promise<EstimateReturn> {
         return {
             estimate: this._getValue(value),
             estimateInfo: null
         };
     }
 
-    async estimateBtoA(value: ValueTypes) {
+    async estimateBtoA(value: ValueTypes): Promise<EstimateReturn> {
         return {
             estimate: this._getValue(value),
             estimateInfo: null


### PR DESCRIPTION
While using the changes introduced in https://github.com/burner-wallet/burner-wallet-2/pull/24 I found that by not providing explicitly the types to the methods `estimateXtoY` in Bridge class that extends Pair, the wrong types were generated.

These are the types generated for `estimateAtoB` and `estimateBtoA` in `Pair`.
```typescript
export interface EstimateReturn {
    estimate: string;
    estimateInfo?: null | string;
}

estimateAtoB(value: ValueTypes): Promise<EstimateReturn>;
estimateBtoA(value: ValueTypes): Promise<EstimateReturn>;
```

And these are the generated in `Bridge`
```typescript
estimateAtoB(value: ValueTypes): Promise<{
        estimate: string;
        estimateInfo: null;
    }>;
estimateBtoA(value: ValueTypes): Promise<{
    estimate: string;
    estimateInfo: null;
}>;
```
This produces errors when trying to return `string` values for `estimateInfo` in classes that extend `Bridge`.

```
Type '(value: ValueTypes) => Promise<EstimateReturn>' is not assignable to type '(value: ValueTypes) => Promise<{ estimate: string; estimateInfo: null; }>'.
```

To fix this, this PR specifies the returned values types also in `Bridge`